### PR TITLE
fix(partners): move Imparago from Open Source Projects to Media Partners

### DIFF
--- a/src/config/editions/2026.json
+++ b/src/config/editions/2026.json
@@ -46,9 +46,8 @@
     "alessandro-liscio",
     "federico-quaglia",
     "kostis-kapelonis",
-    "massimo-bandinelli",
     "stephane-montri",
-    "amedeo-palopoli"
+    "chiara-corrado"
   ],
   "coreTeam": [
     "michel-murabito",

--- a/src/config/editions/2026.json
+++ b/src/config/editions/2026.json
@@ -93,14 +93,14 @@
       "cloudnative-pg",
       "falco",
       "cilium",
-      "krateo",
-      "imparago"
+      "krateo"
     ],
     "media": [
       "cloud-native-trento",
       "italia-open-source",
       "gdg-vicenza",
       "azure-meetup-veneto",
+      "imparago",
       "schroedinger-hat",
       "coderful",
       "tlfe"


### PR DESCRIPTION
Move Imparago from Open Source Projects to Media Partners. They cannot be present at their desk during the event.