### PR TITLE
Add Jacopo Nardiello lightning talk on ING's cloud native journey

### DIFF
--- a/src/config/profiles/jacopo-nardiello.md
+++ b/src/config/profiles/jacopo-nardiello.md
@@ -1,9 +1,9 @@
 ---
 id: "jacopo-nardiello"
 name: "Jacopo Nardiello"
-role: "Head of Cloud Native Services & Open Source"
-company: "ReeVo"
-companyWebsite: "https://www.reevo.it/"
+role: "Global Infrastructure Transformation Lead"
+company: "ING"
+companyWebsite: "https://www.ing.com/"
 communityRole: "CNCF Ambassador & Linux Foundation Europe advisory board member"
 image: "/images/profiles/jacopo-nardiello.webp"
 linkedin: "https://www.linkedin.com/in/jnardiello/"
@@ -11,4 +11,4 @@ github: ""
 website: ""
 ---
 
-Jacopo Nardiello is a DevOps and Kubernetes Engineer passionate about infrastructure automation, orchestration, and distributed systems. Focused on architecture and engineering of distributed systems based on Containers and Kubernetes, he founded SIGHUP in 2016. Currently Chief Cloud Native Officer at ReeVo Cloud & Cyber Security, he is also a CNCF Ambassador and a member of the Linux Foundation Europe Advisory Board.
+Jacopo Nardiello is a DevOps and Kubernetes Engineer passionate about infrastructure automation, orchestration, and distributed systems. Focused on architecture and engineering of distributed systems based on Containers and Kubernetes, he founded SIGHUP in 2016. Currently Global Infrastructure Transformation Lead at ING, he is also a CNCF Ambassador and a member of the Linux Foundation Europe Advisory Board.

--- a/src/config/talks/2026/lightning-talk-tba-6.md
+++ b/src/config/talks/2026/lightning-talk-tba-6.md
@@ -1,9 +1,9 @@
 ---
 id: lightning-talk-tba-6
-title: 'Lightning Talk TBA'
+title: 'Un decennio di Cloud Native: la rotta di ING'
 type: lightning-talk
 speakerIds:
-  - placeholder
+  - jacopo-nardiello
 tags:
   - ITA
 level: all
@@ -12,4 +12,4 @@ video: ''
 slide: ''
 ---
 
-Lightning talk details will be announced soon.
+Cosa significa portare Kubernetes nel cuore di una banca globale? Un viaggio rapido attraverso quasi dieci anni di percorso cloud native in ING: dalle prime adozioni a Kubernetes consumato come namespace-as-a-service, fino alla prossima generazione di Internal Developer Platform. Qualche lezione, qualche cicatrice e la direzione che stiamo prendendo.


### PR DESCRIPTION
## Summary
- Fill the remaining TBA lightning talk slot (`lightning-talk-tba-6`, track1, ITA) with Jacopo Nardiello's talk *"Un decennio di Cloud Native: la rotta di ING"*
- Update Jacopo Nardiello's profile: role → *Global Infrastructure Transformation Lead*, company → *ING* (was ReeVo), with refreshed bio

## Test plan
- [ ] Verify talk renders correctly on the agenda page
- [ ] Verify Jacopo Nardiello's profile page shows the updated role/company
- [ ] Verify the talk is linked from the agenda (track1 slot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)