### PR TITLE
feat(faq): add transport strike alert banner for May 18

### DIFF
--- a/src/components/faq/FaqPage.js
+++ b/src/components/faq/FaqPage.js
@@ -15,8 +15,41 @@ import {
   UtensilsCrossed,
   Star,
   Coffee,
+  TriangleAlert,
 } from 'lucide-react';
 
+/* ── Alert Banner ────────────────────────────────────── */
+function AlertBanner({ alert }) {
+  if (!alert) return null;
+
+  return (
+    <div className='max-w-3xl mx-auto mb-12 bg-amber-50 border border-amber-300 rounded-xl p-6'>
+      <div className='flex items-center gap-3 mb-3'>
+        <TriangleAlert className='h-5 w-5 text-amber-600 flex-shrink-0' />
+        <h2 className='font-bold text-amber-900 text-lg'>{alert.title}</h2>
+      </div>
+      <p className='text-amber-800 text-sm mb-4'>{renderRichText(alert.intro)}</p>
+      {alert.sections.map((section, i) => (
+        <div key={i} className='mb-3'>
+          <p className='font-semibold text-amber-900 text-sm mb-1'>{section.label}:</p>
+          <ul className='space-y-1'>
+            {section.items.map((item, j) => (
+              <li key={j} className='text-amber-800 text-sm flex gap-2'>
+                <span className='mt-0.5 text-amber-500'>-</span>
+                <span>{renderRichText(item)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      {alert.closing && (
+        <p className='mt-4 text-amber-800 text-sm font-medium'>{alert.closing}</p>
+      )}
+    </div>
+  );
+}
+
+/* ── FAQ section ─────────────────────────────────────── */
 const transportIconMap = { Car, Plane, Train, Bus, MapPin };
 const infoIconMap = { Cloud, Landmark, UtensilsCrossed };
 const hotelIconMap = { Star, Coffee };
@@ -338,6 +371,9 @@ export default function FaqPage({ data }) {
   return (
     <div className='bg-gray-50'>
       <div className='container mx-auto max-w-7xl px-4 py-16 lg:py-24'>
+        {/* Alert */}
+        <AlertBanner alert={data.alert} />
+
         {/* Header */}
         <div className='text-center max-w-3xl mx-auto mb-16'>
           <span className='text-sm font-bold text-blue-600 uppercase tracking-wider'>

--- a/src/config/faq.json
+++ b/src/config/faq.json
@@ -4,6 +4,29 @@
     "title": "FAQ 🍕",
     "description": "Find answers to the most common questions about Cloud Native Days Italy 2026, and everything you need to plan your visit to Bologna."
   },
+  "alert": {
+    "title": "Transport Strike Alert - Monday, May 18",
+    "intro": "Quick heads-up: **national strike in Italy on Monday** affecting trains, buses, and airport transit in Bologna.",
+    "sections": [
+      {
+        "label": "Key info",
+        "items": [
+          "Trains: [all-day strike](https://www.trenitalia.com/it/informazioni/treni-garantiti-incasodisciopero.html) with [limited service](https://www.trenitalia.com/content/dam/trenitalia/allegati/info/treni-garantiti/TABELLA_A_Treni_garantiti_DPLH.pdf) between 6-9 AM and 6-9 PM",
+          "Bologna buses: strike during 8:30 AM-4:30 PM and 7:30 PM-EOD",
+          "Marconi Express: all-day strike, uncertain service"
+        ]
+      },
+      {
+        "label": "Recommendations",
+        "items": [
+          "**Arrive early** if traveling Monday",
+          "Use [Cotabo app](https://www.cotabo.it/) for taxis when in Bologna",
+          "Build in **extra time**"
+        ]
+      }
+    ],
+    "closing": "Already in Bologna on Sunday before 21:00? You're all set."
+  },
   "faq": {
     "label": "Frequently Asked Questions",
     "eyebrow": "Did you try turning it off and on again?",


### PR DESCRIPTION
- Add prominent amber alert banner at the top of the FAQ page warning about the national transport strike on Monday May 18
- Banner includes key info on trains, Bologna buses, and Marconi Express, plus travel recommendations
- Data-driven: removing the \`alert\` key from \`faq.json\` hides the banner with no code changes needed